### PR TITLE
Trigger n8n webhook on order placed

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -29,3 +29,6 @@ POSTMARK_FROM_EMAIL=
 # MEILISEARCH_HOST=your-meilisearch-host # e.g. http://localhost:7700
 # MEILISEARCH_MASTER_KEY=your-master-key # Required if MEILISEARCH_ADMIN_KEY is not set
 # MEILISEARCH_ADMIN_KEY=your-admin-key # Optional - if not set, will be fetched using master key
+
+# n8n Webhook to trigger on order placement
+N8N_ORDER_PLACED_WEBHOOK_URL=

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,6 +5,7 @@ Video instructions: https://youtu.be/PPxenu7IjGM
 - `pnpm install` or `npm i`
 - Rename `.env.template` ->  `.env`
 - To connect to your online database from your local machine, copy the `DATABASE_URL` value auto-generated on Railway and add it to your `.env` file.
+  - Optionally set `N8N_ORDER_PLACED_WEBHOOK_URL` to the webhook endpoint for triggering your n8n workflow when orders are placed.
   - If connecting to a new database, for example a local one, run `pnpm ib` or `npm run ib` to seed the database.
 - `pnpm dev` or `npm run dev`
 

--- a/backend/src/lib/constants.ts
+++ b/backend/src/lib/constants.ts
@@ -107,6 +107,12 @@ export const MEILISEARCH_HOST = process.env.MEILISEARCH_HOST;
 export const MEILISEARCH_ADMIN_KEY = process.env.MEILISEARCH_ADMIN_KEY;
 
 /**
+ * (optional) n8n webhook URL triggered when an order is placed
+ */
+export const N8N_ORDER_PLACED_WEBHOOK_URL =
+  process.env.N8N_ORDER_PLACED_WEBHOOK_URL;
+
+/**
  * Worker mode
  */
 export const WORKER_MODE =

--- a/backend/src/subscribers/order-webhook.ts
+++ b/backend/src/subscribers/order-webhook.ts
@@ -1,0 +1,68 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { Modules } from "@medusajs/framework/utils"
+import { N8N_ORDER_PLACED_WEBHOOK_URL } from "../lib/constants"
+
+export default async function orderPlacedWebhook(
+  { event: { data }, container }: SubscriberArgs<{ id: string }>
+) {
+  const logger = container.resolve("logger")
+  if (!N8N_ORDER_PLACED_WEBHOOK_URL) {
+    logger.warn("N8N webhook URL not configured; skipping")
+    return
+  }
+
+  try {
+    const orderModuleService: any = container.resolve(Modules.ORDER)
+    let order
+    if (typeof orderModuleService.retrieve === "function") {
+      order = await orderModuleService.retrieve(data.id, {
+        relations: ["shipping_address"],
+        select: [
+          "id",
+          "created_at",
+          "total",
+          "payment_status",
+          "fulfillment_status",
+        ],
+      })
+    } else if (typeof orderModuleService.retrieveOrder === "function") {
+      order = await orderModuleService.retrieveOrder(data.id, {
+        relations: ["shipping_address"],
+        select: [
+          "id",
+          "created_at",
+          "total",
+          "payment_status",
+          "fulfillment_status",
+        ],
+      })
+    }
+
+    if (!order) {
+      logger.warn(`Order ${data.id} not found`)
+      return
+    }
+
+    const payload = {
+      id: order.id,
+      created_at: order.created_at,
+      total: order.total,
+      shipping_address: order.shipping_address,
+      payment_status: order.payment_status,
+      fulfillment_status: order.fulfillment_status,
+    }
+
+    await fetch(N8N_ORDER_PLACED_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    })
+    logger.info(`Order ${order.id} sent to n8n webhook`)
+  } catch (err: any) {
+    logger.error(`Failed to call n8n webhook for order ${data.id}: ${err.message || err}`)
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}


### PR DESCRIPTION
## Summary
- add environment variable for n8n webhook URL
- call n8n webhook when an order is placed
- document new configuration option

## Testing
- `npm run build` *(fails: `medusa: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d8965c0d88321bff675f610e94f92